### PR TITLE
Verify Privacy Guides data against GitHub attestation

### DIFF
--- a/.github/scripts/generate_internal_db.py
+++ b/.github/scripts/generate_internal_db.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 """Generate InternalVerificationInfoDatabase.kt from privacyguides/verified-apps data.yml."""
 
+import argparse
 import re
 import sys
 import urllib.request
 import codecs
 
 import yaml
-
-PRIVACYGUIDES_URL = "https://raw.githubusercontent.com/privacyguides/verified-apps/main/data.yml"
 
 UPSTREAM_DB_URL = (
     "https://raw.githubusercontent.com/soupslurpr/AppVerifier/main/"
@@ -122,9 +121,9 @@ def privacyguides_to_source(name, extra_map=None):
     return None
 
 
-def fetch_yaml(url):
-    with urllib.request.urlopen(url) as f:
-        return yaml.safe_load(f.read().decode("utf-8"))
+def load_yaml_file(path):
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f)
 
 
 def fetch_upstream_database(url):
@@ -393,7 +392,19 @@ def check_schema(raw):
 
 
 def main():
-    privacyguides_data = fetch_yaml(PRIVACYGUIDES_URL)
+    parser = argparse.ArgumentParser(
+        description="Sync InternalVerificationInfoDatabase.kt from privacyguides/verified-apps."
+    )
+    parser.add_argument(
+        "--data-yml",
+        metavar="PATH",
+        required=True,
+        help="Path to attestation-verified privacyguides/verified-apps data.yml",
+    )
+    args = parser.parse_args()
+
+    privacyguides_data = load_yaml_file(args.data_yml)
+
     check_schema(privacyguides_data)
     if isinstance(privacyguides_data, dict):
         privacyguides_data = privacyguides_data.get("packages", [])

--- a/.github/workflows/sync-verified-apps.yml
+++ b/.github/workflows/sync-verified-apps.yml
@@ -4,23 +4,32 @@ on:
 
 permissions:
   contents: write
+  attestations: read
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    env:
+      PRIVACYGUIDES_DATA_URL: https://raw.githubusercontent.com/privacyguides/verified-apps/main/data.yml
     steps:
       - uses: actions/checkout@v6
         with:
           ref: feature/all-enhancements
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download verified-apps database
+        run: curl -fsSL -o "$RUNNER_TEMP/data.yml" "$PRIVACYGUIDES_DATA_URL"
+      - name: Verify database attestation
+        run: gh attestation verify --owner privacyguides "$RUNNER_TEMP/data.yml"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install dependencies
         run: pip install pyyaml
       - name: Run sync script
-        run: python .github/scripts/generate_internal_db.py
+        run: python .github/scripts/generate_internal_db.py --data-yml "$RUNNER_TEMP/data.yml"
       - name: Commit changes
         id: commit
         run: |
@@ -30,7 +39,9 @@ jobs:
           if git diff --quiet HEAD; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "Sync privacyguides/verified-apps database"
+            git commit \
+              -m "Sync privacyguides/verified-apps database" \
+              -m "Co-authored-by: Privacy Guides [bot] <github-bot@privacyguides.net>"
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
             git push
           fi


### PR DESCRIPTION
**Minor change:** Co-authors your database grabs with `Privacy Guides [bot] <github-bot@privacyguides.net>`.

I don't really care, so you don't have to keep this if you don't want to, but I thought it might make looking through the commit history a tad easier. Actually, I don't even see any "Sync privacyguides/verified-apps database" commits in your repo, so maybe you don't want this at all. If you are squashing commits or simply don't want this, feel free to remove from the PR 🤷‍♂️ 

---

**Main change:** This adds a step to your workflow to verify data.yml grabs against GitHub's [attestations](https://github.com/privacyguides/verified-apps/attestations) (see https://discuss.privacyguides.net/t/submit-android-apps-to-our-appverifier-database/38125/17).

I am not sure if this is actually very important for you currently, because you are grabbing the data directly from GitHub inside a GitHub workflow, so there should not really be any risk of a "supply chain attack."

However, it lays the groundwork for (one or both of) two things in the future:

- Eventually we will publish `data.yml` to a privacyguides.org domain that we host separate from GitHub. When we do, you could start downloading data.yml from that website instead of GitHub, but then you use GitHub's attestations to verify the version we host matches the version that's on GitHub, so you're checking against two sources of truth.

- You can switch to grabbing `data.yml` files from our releases instead of main (which I wouldn't do _yet_ since we are not "releasing" regularly, but we will release more frequently in the future). Then you can verify your download against an immutable release instead of main, e.g. by changing the command to:

  ```
  gh release verify-asset 3.20260527 data.yml
  ```

I tested with a valid data.yml file and an invalid one, and this workflow appears to work as expected in my repo.